### PR TITLE
type-fix: Make body optional...

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import deparam from 'deparam';
 
 interface INetworkRequestResponse {
-  body: any; // POJO or a JSON stringify equalivant
+  body?: any; // POJO or a JSON stringify equalivant
   method: string;
   headers: object;
 }


### PR DESCRIPTION
... in the `INetworkRequestResponse` interface. This will help merge cleanly with `LR.IRequest` and fixes https://github.com/LogRocket/logrocket-fuzzy-search-sanitizer/issues/5.